### PR TITLE
Update TMFC014 - Component-OAS-Specification-v1beta2.yaml

### DIFF
--- a/TMFC014 Location Management/TMFC014 - Component-OAS-Specification-v1beta2.yaml
+++ b/TMFC014 Location Management/TMFC014 - Component-OAS-Specification-v1beta2.yaml
@@ -80,7 +80,7 @@ coreFunction:
           id: TMF701
           isRequired: no
           version: 4.0
-          specification: ttps://raw.githubusercontent.com/tmforum-apis/TMF701_ProcessFlow/master/TMF701-ProcessFlow-v4.0.0.swagger.json
+          specification: https://raw.githubusercontent.com/tmforum-apis/TMF701_ProcessFlow/master/TMF701-ProcessFlow-v4.0.0.swagger.json
           implementation: /{{.Release.Name}}-ProcessFlowManagement
           apitype: openapi
           path: /{{.Release.Name}}-{{.Values.component.type}}/tmf-api/ProcessFlowManagement/v4
@@ -124,10 +124,13 @@ coreFunction:
       path: /{{.Release.Name}}-{{.Values.component.type}}/tmf-api/PartyManagement/v4
       developerUI: /{{.Release.Name}}-{{.Values.component.type}}/tmf-api/PartyManagement/v4/docs
       port: 8080
-      resources:  
-      - PartyManagement:
-        - GET
-        - GET /id
+      resources:
+        - individual:
+            - GET
+            - GET /id
+        - organization:
+            - GET
+            - GET /id
     - name: GeographicSiteManagement
       id: TMF674
       version: 4.0
@@ -145,6 +148,7 @@ coreFunction:
       apitype: openapi     
       resources: 
       - event:
+        - POST
         - GET
         - GET /id                                  
     publishedEvents: 


### PR DESCRIPTION
Line 83: misspelled words “ttps” -> “https"
Line 127-130 TMF632 PartyManagement dependant API should be “individual” and “organization"
Line 151 add “post” method